### PR TITLE
Add Module::Metadata to replace the deprecated Module::Build::ModuleInfo

### DIFF
--- a/inc/My_Build.pm
+++ b/inc/My_Build.pm
@@ -21,6 +21,7 @@ use strict;
 use warnings;
 use File::Spec ();
 use Module::Build ();
+use Module::Metadata ();
 
 use base 'Module::Build';
 
@@ -40,7 +41,7 @@ sub process_xs
 
   # Get the version number from the corresponding .pm file:
   $pm_file =~ s/\.xs$/.pm/i or die "$pm_file: Not an .xs file";
-  my $pm_info = Module::Build::ModuleInfo->new_from_file($pm_file)
+  my $pm_info = Module::Metadata->new_from_file($pm_file)
       or die "Can't find file $pm_file to determine version";
 
   # Tell dist_version to use it:


### PR DESCRIPTION
Using the latest version of "Module::Build" (0.4210), the Build process
for Win32::IPC failed with error message:

Building Win32-IPC
Can't locate object method "new_from_file" via package "Module::Build::ModuleInfo"
(perhaps you forgot to load "Module::Build::ModuleInfo"?) at inc/My_Build.pm line 43.

This is a comment from https://metacpan.org/pod/Module::Build::ModuleInfo

Module::Build::ModuleInfo - DEPRECATED - version 0.4210
DESCRIPTION - This module has been extracted into a separate distribution
and renamed Module::Metadata. This module is kept as a subclass wrapper
for compatibility.
